### PR TITLE
Hotfix 3 4/bug processing dependent files

### DIFF
--- a/TextureHandler.php
+++ b/TextureHandler.php
@@ -647,8 +647,8 @@ class TextureHandler extends Handler {
 	 * @return void
 	 */
 	public function media($args, $request) {
-		$fileId = (int) $request->getUserVar('fileId'); // ← este es el ID que querés servir
-		$assocId = (int) $request->getUserVar('assocId'); // ← este es el XML base (submissionFile)
+		$fileId = (int) $request->getUserVar('fileId');
+		$assocId = (int) $request->getUserVar('assocId'); 
 		$submissionFile = Repo::submissionFile()->get($assocId);
 
 		if (!$submissionFile) {
@@ -660,8 +660,9 @@ class TextureHandler extends Handler {
 			->filterBySubmissionIds([$submissionFile->getData('submissionId')])
 			->filterByFileStages([SUBMISSION_FILE_DEPENDENT])
 			->getMany()
-			->filter(function($file) use ($fileId) {
-        		return $file->getData('fileId') === $fileId;
+			->filter(function ($file) use ($assocId) {
+				return $file->getData('assocType') === ASSOC_TYPE_SUBMISSION_FILE
+					&& $file->getData('assocId') === $assocId;
 			});
 
 		$mediaFile = $dependentFiles->first(function ($file) use ($fileId) {

--- a/classes/DAR.php
+++ b/classes/DAR.php
@@ -199,17 +199,12 @@ class DAR {
 			if ((int) $file->getData('assocId') !== $submissionFileId) continue;
 			$fileName = $file->getLocalizedData('name');
 
-			error_log("FILENAME:" . $fileName);
-
-			error_log("FILE DATA: " . print_r($file, true));
-
 			if (!$fileName) continue;
 			$base = strtolower(basename($fileName));
 			$byBasename[$base] = $file;
 		}
 
 		foreach ((array) $assets as $assetMeta) {
-			error_log("ASSET META: " . print_r($assetMeta, true));
 
 			if (!isset($assetMeta['path'])) continue;
 			$path = $assetMeta['path'];

--- a/classes/DAR.php
+++ b/classes/DAR.php
@@ -134,7 +134,6 @@ class DAR {
 			$figItem = $figElements->item($k);
 			$graphic = $figItem->getElementsByTagName('graphic');
 			if (sizeof($graphic) > 0) {
-
 				// figure without graphic?
 				if (!$figItem || !$graphic) {
 					continue;
@@ -184,32 +183,53 @@ class DAR {
 		$router = $request->getRouter();
 		$dispatcher = $router->getDispatcher();
 
-		$submissionFileId = $request->getUserVar('submissionFileId');
+		$submissionFileId = (int) $request->getUserVar('submissionFileId');
 		$stageId = $request->getUserVar('stageId');
-		$submissionId = $request->getUserVar('submissionId');
-		$submissionFiles = Repo::submissionFile()
+		$submissionId = (int) $request->getUserVar('submissionId');
+
+		$dependentFiles = Repo::submissionFile()
 			->getCollector()
 			->filterBySubmissionIds([$submissionId])
 			->filterByFileStages([SUBMISSION_FILE_DEPENDENT])
-			->getMany(); 
+			->getMany();
+		
+		$byBasename = [];
+		foreach ($dependentFiles as $file) {
+			if ($file->getData('assocType') !== ASSOC_TYPE_SUBMISSION_FILE) continue;
+			if ((int) $file->getData('assocId') !== $submissionFileId) continue;
+			$fileName = $file->getLocalizedData('name');
 
+			error_log("FILENAME:" . $fileName);
 
+			error_log("FILE DATA: " . print_r($file, true));
 
-		foreach ($submissionFiles as $asset) {
+			if (!$fileName) continue;
+			$base = strtolower(basename($fileName));
+			$byBasename[$base] = $file;
+		}
+
+		foreach ((array) $assets as $assetMeta) {
+			error_log("ASSET META: " . print_r($assetMeta, true));
+
+			if (!isset($assetMeta['path'])) continue;
+			$path = $assetMeta['path'];
+			$base = strtolower(basename($path));
+			if (!isset($byBasename[$base])) continue;
+			$file = $byBasename[$base];
+
 			$url = $dispatcher->url($request, ROUTE_PAGE, null, 'texture', 'media', null, array(
 				'submissionId' => $submissionId,
 				'stageId' => $stageId,
 				'assocId' => $submissionFileId,
-				'fileId' => $asset->getData('fileId')
-
+				'fileId' => $file->getData('fileId')
 			));
 
-			$infos[$asset->getLocalizedData('name')] = array(
+			$infos[$path] = array(
 				'encoding' => 'url',
 				'data' => $url
 			);
-
 		}
+
 		return $infos;
 	}
 


### PR DESCRIPTION
En la actualización a Texture para OJS 3.4 se detectó un bug en la migración que afecta la forma en que se recuperan los archivos dependientes al momento de editar un XML. El problema consiste en que cuando se está editando un XML se listan imágenes que no corresponden a la etapa en la que se encuentra el archivo que se está editando, mostrando imágenes que en realidad no son dependientes de ese XML. 